### PR TITLE
[BE] fix: 검색 기록 상세조회시 널값 오류 해결

### DIFF
--- a/Dalum-BE/src/main/java/dalum/dalum/domain/product/dto/response/ProductDto.java
+++ b/Dalum-BE/src/main/java/dalum/dalum/domain/product/dto/response/ProductDto.java
@@ -19,7 +19,7 @@ public record ProductDto(
         String category,
 
         @Schema(description = "가격", example = "100000")
-        int price,
+        Integer price,
 
         @Schema(description = "이미지 주소", example = "https://example.com/image.jpg")
         String imageUrl,
@@ -28,7 +28,7 @@ public record ProductDto(
         String purchaseUrl,
 
         @Schema(description = "유사도", example = "0.85")
-        double similarity,
+        Double similarity,
 
         @Schema(description = "좋아요 여부", example = "true")
         boolean isLiked

--- a/Dalum-BE/src/main/java/dalum/dalum/domain/search_log/dto/response/SearchConditionDto.java
+++ b/Dalum-BE/src/main/java/dalum/dalum/domain/search_log/dto/response/SearchConditionDto.java
@@ -6,9 +6,9 @@ import lombok.Builder;
 @Builder
 public record SearchConditionDto(
         @Schema(description = "최소가격", example = "10000")
-        int minPrice,
+        Integer minPrice,
 
         @Schema(description = "최대가격", example = "50000")
-        int maxPrice
+        Integer maxPrice
 ) {
 }


### PR DESCRIPTION
## 📝작업 내용
> 검색 기록 상세조회시 브랜드, 최소가격, 최대가격 널값 오류 해결

### 스크린샷 (선택)
<img width="1062" height="450" alt="image" src="https://github.com/user-attachments/assets/4e2c10d1-292e-42a1-a9af-7c5af36a517b" />

## 💬리뷰 요구사항(선택)
> 없음
